### PR TITLE
CH-005 OTP Verify: establish session cookie (Admin/Foreman)

### DIFF
--- a/backend/src/main/java/com/crewhandshake/common/security/SecurityConfig.java
+++ b/backend/src/main/java/com/crewhandshake/common/security/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
             .requestMatchers("/api/v1/auth/**", "/api/v1/public/**").permitAll()
             .anyRequest().authenticated()
         )
-        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.ALWAYS))
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
         .addFilterBefore(sessionAuthFilter, org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
         .formLogin(form -> form.disable())
         .httpBasic(basic -> basic.disable());

--- a/backend/src/main/java/com/crewhandshake/common/security/SessionService.java
+++ b/backend/src/main/java/com/crewhandshake/common/security/SessionService.java
@@ -2,6 +2,7 @@ package com.crewhandshake.common.security;
 
 import com.crewhandshake.common.errors.ApiErrorCode;
 import com.crewhandshake.common.errors.ApiException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.util.Optional;
 import org.springframework.http.HttpStatus;
@@ -11,14 +12,18 @@ import org.springframework.stereotype.Component;
 public class SessionService {
   public static final String SESSION_KEY = "AUTH_SESSION";
 
-  private final HttpSession httpSession;
+  private final HttpServletRequest request;
 
-  public SessionService(HttpSession httpSession) {
-    this.httpSession = httpSession;
+  public SessionService(HttpServletRequest request) {
+    this.request = request;
   }
 
   public Optional<AuthSession> getSession() {
-    Object value = httpSession.getAttribute(SESSION_KEY);
+    HttpSession session = request.getSession(false);
+    if (session == null) {
+      return Optional.empty();
+    }
+    Object value = session.getAttribute(SESSION_KEY);
     if (value instanceof AuthSession authSession) {
       return Optional.of(authSession);
     }
@@ -34,11 +39,15 @@ public class SessionService {
   }
 
   public void saveSession(AuthSession session) {
+    HttpSession httpSession = request.getSession(true);
     httpSession.setAttribute(SESSION_KEY, session);
   }
 
   public void clearSession() {
-    httpSession.invalidate();
+    HttpSession session = request.getSession(false);
+    if (session != null) {
+      session.invalidate();
+    }
     org.springframework.security.core.context.SecurityContextHolder.clearContext();
   }
 }

--- a/backend/src/test/java/com/crewhandshake/features/auth/AuthSessionCookieTest.java
+++ b/backend/src/test/java/com/crewhandshake/features/auth/AuthSessionCookieTest.java
@@ -1,0 +1,94 @@
+package com.crewhandshake.features.auth;
+
+import com.crewhandshake.common.security.MembershipRole;
+import com.crewhandshake.features.auth.persistence.CompanyEntity;
+import com.crewhandshake.features.auth.persistence.CompanyRepository;
+import com.crewhandshake.features.auth.persistence.IdentityEntity;
+import com.crewhandshake.features.auth.persistence.IdentityRepository;
+import com.crewhandshake.features.auth.persistence.MembershipEntity;
+import com.crewhandshake.features.auth.persistence.MembershipRepository;
+import com.crewhandshake.features.messaging.service.SmsProvider;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthSessionCookieTest {
+  @Autowired
+  private TestRestTemplate restTemplate;
+
+  @Autowired
+  private IdentityRepository identityRepository;
+
+  @Autowired
+  private CompanyRepository companyRepository;
+
+  @Autowired
+  private MembershipRepository membershipRepository;
+
+  @Autowired
+  private TestSmsProvider testSmsProvider;
+
+  @Test
+  void otpVerifyEstablishesSessionCookie() {
+    String phone = "+14155551213";
+
+    ResponseEntity<String> startResponse = restTemplate.postForEntity(
+        "/api/v1/auth/otp/start",
+        Map.of("phone", phone),
+        String.class
+    );
+    assertThat(startResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    IdentityEntity identity = identityRepository.findByPhoneE164(phone).orElseThrow();
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Acme Construction"));
+    membershipRepository.save(new MembershipEntity(company, identity, Set.of(MembershipRole.ADMIN)));
+
+    String code = testSmsProvider.getLastCode();
+    assertThat(code).isNotBlank();
+
+    ResponseEntity<String> verifyResponse = restTemplate.postForEntity(
+        "/api/v1/auth/otp/verify",
+        Map.of("phone", phone, "code", code),
+        String.class
+    );
+    assertThat(verifyResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+    List<String> setCookies = verifyResponse.getHeaders().get("Set-Cookie");
+    assertThat(setCookies).isNotNull();
+    assertThat(setCookies).anyMatch(cookie -> cookie.startsWith("JSESSIONID="));
+  }
+
+  @TestConfiguration
+  static class TestMessagingConfig {
+    @Bean
+    @Primary
+    TestSmsProvider testSmsProvider() {
+      return new TestSmsProvider();
+    }
+  }
+
+  static class TestSmsProvider implements SmsProvider {
+    private String lastCode;
+
+    @Override
+    public void sendOtp(String phoneE164, String code) {
+      this.lastCode = code;
+    }
+
+    String getLastCode() {
+      return lastCode;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Ensure sessions are created only on auth and OTP verify establishes session cookie.
- Add integration test to assert Set-Cookie on OTP verify.

## Sprint scope
- [ ] Sprint 1 only (CH-001, CH-002, CH-003)

## Validation
- [ ] `scripts/lint.sh`
- [ ] `scripts/test.sh`
- [ ] `scripts/build.sh`
- [ ] Manual smoke (app boots; base UI renders; no console errors)
- [x] `backend/mvnw -q -Dtest=AuthSessionCookieTest test`
- [x] `backend/mvnw -q -Dtest=AuthFlowTest test`

## Evidence
- Logs/notes: AuthSessionCookieTest asserts `Set-Cookie: JSESSIONID` on OTP verify response.
- Screenshot(s): N/A
- CI run link: N/A

## Docs
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)

## Issues
Closes CH-005
