### PR TITLE
CH-006 Active company selection + tenant context enforcement

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -60,6 +60,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/main/java/com/crewhandshake/common/tenant/TenantContext.java
+++ b/backend/src/main/java/com/crewhandshake/common/tenant/TenantContext.java
@@ -52,12 +52,16 @@ public class TenantContext {
   }
 
   public void requireAdmin() {
+    requireCompanyId();
+    requireMembershipId();
     if (!isAdmin()) {
       throw new ApiException(ApiErrorCode.FORBIDDEN, HttpStatus.FORBIDDEN, "Not permitted");
     }
   }
 
   public void requireForemanOrAdmin() {
+    requireCompanyId();
+    requireMembershipId();
     if (!(isAdmin() || isForeman())) {
       throw new ApiException(ApiErrorCode.FORBIDDEN, HttpStatus.FORBIDDEN, "Not permitted");
     }

--- a/backend/src/main/java/com/crewhandshake/features/foreman/persistence/TimeEntryRepository.java
+++ b/backend/src/main/java/com/crewhandshake/features/foreman/persistence/TimeEntryRepository.java
@@ -19,6 +19,8 @@ public interface TimeEntryRepository extends JpaRepository<TimeEntryEntity, UUID
 
   Optional<TimeEntryEntity> findByCompanyIdAndWorkerMembershipIdAndWorkDate(UUID companyId, UUID workerMembershipId, LocalDate workDate);
 
+  Optional<TimeEntryEntity> findByCompanyIdAndId(UUID companyId, UUID id);
+
   long countByCompanyIdAndWorkDateBetween(UUID companyId, LocalDate start, LocalDate end);
 
   List<TimeEntryEntity> findByCompanyIdAndWorkDateBetween(UUID companyId, LocalDate start, LocalDate end);

--- a/backend/src/main/java/com/crewhandshake/features/foreman/service/TimeAdjustmentService.java
+++ b/backend/src/main/java/com/crewhandshake/features/foreman/service/TimeAdjustmentService.java
@@ -47,11 +47,8 @@ public class TimeAdjustmentService {
   public TimeAdjustmentResponse adjustTime(TimeAdjustmentRequest request) {
     tenantContext.requireForemanOrAdmin();
     UUID companyId = tenantContext.requireCompanyId();
-    TimeEntryEntity timeEntry = timeEntryRepository.findById(request.timeEntryId())
+    TimeEntryEntity timeEntry = timeEntryRepository.findByCompanyIdAndId(companyId, request.timeEntryId())
         .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND, HttpStatus.NOT_FOUND, "Time entry not found"));
-    if (!timeEntry.getCompany().getId().equals(companyId)) {
-      throw new ApiException(ApiErrorCode.FORBIDDEN, HttpStatus.FORBIDDEN, "Not permitted");
-    }
     ensureCrewScope(timeEntry);
 
     Instant checkInAt = timeParser.parseInstant(request.checkInAt(), "checkInAt");

--- a/backend/src/test/java/com/crewhandshake/features/auth/ActiveCompanySelectionTest.java
+++ b/backend/src/test/java/com/crewhandshake/features/auth/ActiveCompanySelectionTest.java
@@ -1,0 +1,114 @@
+package com.crewhandshake.features.auth;
+
+import com.crewhandshake.common.security.MembershipRole;
+import com.crewhandshake.features.auth.persistence.CompanyEntity;
+import com.crewhandshake.features.auth.persistence.CompanyRepository;
+import com.crewhandshake.features.auth.persistence.IdentityEntity;
+import com.crewhandshake.features.auth.persistence.IdentityRepository;
+import com.crewhandshake.features.auth.persistence.MembershipEntity;
+import com.crewhandshake.features.auth.persistence.MembershipRepository;
+import com.crewhandshake.features.messaging.service.SmsProvider;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ActiveCompanySelectionTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private IdentityRepository identityRepository;
+
+  @Autowired
+  private CompanyRepository companyRepository;
+
+  @Autowired
+  private MembershipRepository membershipRepository;
+
+  @Autowired
+  private TestSmsProvider testSmsProvider;
+
+  @Test
+  void activeCompanyRequiredForAdminEndpoints() throws Exception {
+    String phone = "+14155551214";
+
+    mockMvc.perform(post("/api/v1/auth/otp/start")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"phone\": \"" + phone + "\"}"))
+        .andExpect(status().isOk());
+
+    IdentityEntity identity = identityRepository.findByPhoneE164(phone).orElseThrow();
+    CompanyEntity primary = companyRepository.save(new CompanyEntity("Acme One"));
+    CompanyEntity secondary = companyRepository.save(new CompanyEntity("Acme Two"));
+    membershipRepository.save(new MembershipEntity(primary, identity, Set.of(MembershipRole.ADMIN)));
+    membershipRepository.save(new MembershipEntity(secondary, identity, Set.of(MembershipRole.ADMIN)));
+
+    String code = testSmsProvider.getLastCode();
+    assertThat(code).isNotBlank();
+
+    MvcResult verifyResult = mockMvc.perform(post("/api/v1/auth/otp/verify")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"phone\": \"" + phone + "\", \"code\": \"" + code + "\"}"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    MockHttpSession session = (MockHttpSession) verifyResult.getRequest().getSession(false);
+    assertThat(session).isNotNull();
+
+    mockMvc.perform(get("/api/v1/admin/settings")
+        .session(session))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED"));
+
+    mockMvc.perform(post("/api/v1/me/active-company")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"companyId\": \"" + primary.getId() + "\"}"))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(get("/api/v1/admin/settings")
+        .session(session))
+        .andExpect(status().isOk());
+  }
+
+  @TestConfiguration
+  static class TestMessagingConfig {
+    @Bean
+    @Primary
+    TestSmsProvider testSmsProvider() {
+      return new TestSmsProvider();
+    }
+  }
+
+  static class TestSmsProvider implements SmsProvider {
+    private String lastCode;
+
+    @Override
+    public void sendOtp(String phoneE164, String code) {
+      this.lastCode = code;
+    }
+
+    String getLastCode() {
+      return lastCode;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enforce active company + membership context before admin/foreman role checks
- scope time adjustment lookup to active company
- add integration test for multi-membership active company selection (CSRF included)
- add spring-security-test (test scope only)

## What was not changed
- no frontend/UI updates
- no API contract shape changes
- no auth/CSRF policy changes

## Verification
- `backend\\mvnw.cmd -DskipTests compile`
- `backend\\mvnw.cmd test`
- `backend\\mvnw.cmd -DskipTests package`

## Risk / Rollback
- Risk: low; stricter tenant-context enforcement may return 401 where 403 previously occurred
- Rollback: revert this PR

Closes #CH-006