### PR TITLE
CH-009 Admin Foremen CRUD

### DIFF
--- a/backend/src/test/java/com/crewhandshake/features/admin/AdminForemenTest.java
+++ b/backend/src/test/java/com/crewhandshake/features/admin/AdminForemenTest.java
@@ -1,0 +1,157 @@
+package com.crewhandshake.features.admin;
+
+import com.crewhandshake.common.security.AuthSession;
+import com.crewhandshake.common.security.MembershipRole;
+import com.crewhandshake.common.security.SessionService;
+import com.crewhandshake.features.admin.persistence.ForemanProfileEntity;
+import com.crewhandshake.features.admin.persistence.ForemanProfileRepository;
+import com.crewhandshake.features.auth.persistence.CompanyEntity;
+import com.crewhandshake.features.auth.persistence.CompanyRepository;
+import com.crewhandshake.features.auth.persistence.IdentityEntity;
+import com.crewhandshake.features.auth.persistence.IdentityRepository;
+import com.crewhandshake.features.auth.persistence.MembershipEntity;
+import com.crewhandshake.features.auth.persistence.MembershipRepository;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminForemenTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private CompanyRepository companyRepository;
+
+  @Autowired
+  private IdentityRepository identityRepository;
+
+  @Autowired
+  private MembershipRepository membershipRepository;
+
+  @Autowired
+  private ForemanProfileRepository foremanProfileRepository;
+
+  @Test
+  void createForemanRequiresPhone() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Foremen Co"));
+    MembershipEntity admin = createMembership(company, Set.of(MembershipRole.ADMIN), "+14155560001");
+    MockHttpSession session = sessionFor(company, admin);
+
+    mockMvc.perform(post("/api/v1/admin/foremen")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Lead\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.fieldErrors.phone").exists());
+  }
+
+  @Test
+  void createAndUpdateForeman() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Roster Co"));
+    MembershipEntity admin = createMembership(company, Set.of(MembershipRole.ADMIN), "+14155560002");
+    MockHttpSession session = sessionFor(company, admin);
+
+    mockMvc.perform(post("/api/v1/admin/foremen")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Lead\",\"phone\":\"+14155561001\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("Lead"));
+
+    List<ForemanProfileEntity> foremen = foremanProfileRepository.findByCompanyId(company.getId());
+    ForemanProfileEntity foreman = foremen.get(0);
+
+    mockMvc.perform(put("/api/v1/admin/foremen")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"membershipId\":\"" + foreman.getMembershipId() + "\",\"displayName\":\"Lead\",\"active\":false}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.active").value(false));
+
+    mockMvc.perform(get("/api/v1/admin/foremen")
+        .session(session))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].active").value(false));
+  }
+
+  @Test
+  void foremanCannotAccessAdminForemen() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Foreman Blocked"));
+    MembershipEntity foreman = createMembership(company, Set.of(MembershipRole.FOREMAN), "+14155560003");
+    MockHttpSession session = sessionFor(company, foreman);
+
+    mockMvc.perform(get("/api/v1/admin/foremen")
+        .session(session))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+  }
+
+  @Test
+  void listForemenIsScopedToActiveCompany() throws Exception {
+    CompanyEntity primary = companyRepository.save(new CompanyEntity("Primary Co"));
+    CompanyEntity secondary = companyRepository.save(new CompanyEntity("Secondary Co"));
+    MembershipEntity primaryAdmin = createMembership(primary, Set.of(MembershipRole.ADMIN), "+14155560004");
+    MembershipEntity secondaryAdmin = createMembership(secondary, Set.of(MembershipRole.ADMIN), "+14155560005");
+    MockHttpSession primarySession = sessionFor(primary, primaryAdmin);
+    MockHttpSession secondarySession = sessionFor(secondary, secondaryAdmin);
+
+    mockMvc.perform(post("/api/v1/admin/foremen")
+        .session(primarySession)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Primary Lead\",\"phone\":\"+14155560006\"}"))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(post("/api/v1/admin/foremen")
+        .session(secondarySession)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Secondary Lead\",\"phone\":\"+14155560007\"}"))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(get("/api/v1/admin/foremen")
+        .session(primarySession))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].displayName").value("Primary Lead"));
+  }
+
+  private MembershipEntity createMembership(CompanyEntity company, Set<MembershipRole> roles, String phone) {
+    IdentityEntity identity = identityRepository.save(new IdentityEntity(phone));
+    return membershipRepository.save(new MembershipEntity(company, identity, roles));
+  }
+
+  private MockHttpSession sessionFor(CompanyEntity company, MembershipEntity membership) {
+    AuthSession session = new AuthSession(
+        membership.getIdentity().getId(),
+        membership.getIdentity().getPhoneE164(),
+        company.getId(),
+        membership.getId(),
+        membership.getRoles()
+    );
+    MockHttpSession httpSession = new MockHttpSession();
+    httpSession.setAttribute(SessionService.SESSION_KEY, session);
+    return httpSession;
+  }
+}

--- a/frontend/src/app/features/admin/pages/foremen.page.css
+++ b/frontend/src/app/features/admin/pages/foremen.page.css
@@ -1,0 +1,17 @@
+.foremen-active {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-1);
+}
+
+.foremen-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  flex-wrap: wrap;
+}
+
+.foremen-row--editing {
+  background: var(--ds-color-primary-subtle);
+}

--- a/frontend/src/app/features/admin/pages/foremen.page.html
+++ b/frontend/src/app/features/admin/pages/foremen.page.html
@@ -3,7 +3,7 @@
     class="ds-button ds-button--secondary"
     type="button"
     (click)="load()"
-    [disabled]="loading()"
+    [disabled]="isBusy()"
   >
     Refresh
   </button>
@@ -19,14 +19,12 @@
         class="ds-input"
         type="text"
         formControlName="displayName"
-        [class.ds-input--error]="
-          form.controls.displayName.touched && form.controls.displayName.invalid
-        "
-        aria-describedby="foreman-name-error"
-        [attr.aria-invalid]="form.controls.displayName.touched && form.controls.displayName.invalid"
+        [class.ds-input--error]="!!nameError()"
+        [attr.aria-describedby]="nameErrorId()"
+        [attr.aria-invalid]="nameError() ? 'true' : null"
       />
-      @if (form.controls.displayName.touched && form.controls.displayName.invalid) {
-        <p id="foreman-name-error" class="ds-error-text" role="status">Name is required.</p>
+      @if (nameError()) {
+        <app-field-error [id]="nameErrorId()" [message]="nameError()"></app-field-error>
       }
     </div>
 
@@ -39,23 +37,33 @@
           type="tel"
           formControlName="phone"
           autocomplete="tel"
-          [class.ds-input--error]="form.controls.phone.touched && form.controls.phone.invalid"
-          aria-describedby="foreman-phone-error"
-          [attr.aria-invalid]="form.controls.phone.touched && form.controls.phone.invalid"
+          [class.ds-input--error]="!!phoneError()"
+          [attr.aria-describedby]="phoneErrorId()"
+          [attr.aria-invalid]="phoneError() ? 'true' : null"
         />
-        @if (form.controls.phone.touched && form.controls.phone.invalid) {
-          <p id="foreman-phone-error" class="ds-error-text" role="status">Phone is required.</p>
+        @if (phoneError()) {
+          <app-field-error [id]="phoneErrorId()" [message]="phoneError()"></app-field-error>
         }
       </div>
     }
 
-    <label class="ds-field ds-checkbox-field">
-      <span class="ds-label">Active</span>
-      <input type="checkbox" formControlName="active" />
-    </label>
+    <div class="foremen-active">
+      <label class="ds-field ds-checkbox-field" for="foreman-active">
+        <span class="ds-label">Active</span>
+        <input
+          id="foreman-active"
+          type="checkbox"
+          formControlName="active"
+          aria-describedby="foreman-active-help"
+        />
+      </label>
+      <p id="foreman-active-help" class="ds-helper">
+        Inactive foremen keep their history but cannot access crew tools.
+      </p>
+    </div>
 
     <div class="ds-inline-actions">
-      <button class="ds-button ds-button--primary" type="submit" [disabled]="loading()">
+      <button class="ds-button ds-button--primary" type="submit" [disabled]="isBusy()">
         {{ submitLabel() }}
       </button>
       @if (isEditing()) {
@@ -63,7 +71,7 @@
           class="ds-button ds-button--ghost"
           type="button"
           (click)="onCancelEdit()"
-          [disabled]="loading()"
+          [disabled]="isBusy()"
         >
           Cancel
         </button>
@@ -71,10 +79,19 @@
     </div>
   </form>
 
-  @if (error()) {
-    <div class="ds-alert ds-alert--error" role="status" aria-live="polite">
-      {{ error()?.message }}
-    </div>
+  @if (submitError()) {
+    <app-error-banner
+      [message]="submitError()?.message ?? 'Something went wrong.'"
+    ></app-error-banner>
+  }
+
+  @if (loadError()) {
+    <app-error-banner
+      [message]="loadError()?.message ?? 'Unable to load foremen.'"
+      [showRetry]="true"
+      retryLabel="Retry"
+      (retry)="load()"
+    ></app-error-banner>
   }
 
   @if (loading()) {
@@ -83,10 +100,12 @@
     </div>
   } @else {
     @if (foremen().length === 0) {
-      <app-empty-state
-        title="No foremen yet"
-        description="Add a foreman to assign crew leadership."
-      ></app-empty-state>
+      @if (!loadError()) {
+        <app-empty-state
+          title="No foremen yet"
+          description="Add a foreman to assign crew leadership."
+        ></app-empty-state>
+      }
     } @else {
       <div class="ds-table-wrap">
         <table class="ds-table" aria-label="Foremen">
@@ -100,7 +119,7 @@
           </thead>
           <tbody>
             @for (foreman of foremen(); track trackById($index, foreman)) {
-              <tr>
+              <tr [class.foremen-row--editing]="editingId() === foreman.membershipId">
                 <td>{{ foreman.displayName }}</td>
                 <td>{{ foreman.phoneE164 }}</td>
                 <td>
@@ -110,13 +129,19 @@
                   ></app-status-badge>
                 </td>
                 <td>
-                  <button
-                    class="ds-button ds-button--ghost"
-                    type="button"
-                    (click)="onEdit(foreman)"
-                  >
-                    Edit
-                  </button>
+                  <div class="foremen-actions">
+                    @if (editingId() === foreman.membershipId) {
+                      <span class="ds-chip">Editing</span>
+                    }
+                    <button
+                      class="ds-button ds-button--ghost"
+                      type="button"
+                      (click)="onEdit(foreman)"
+                      [attr.aria-label]="'Edit foreman ' + foreman.displayName"
+                    >
+                      Edit
+                    </button>
+                  </div>
                 </td>
               </tr>
             }

--- a/frontend/src/app/features/admin/pages/foremen.page.spec.ts
+++ b/frontend/src/app/features/admin/pages/foremen.page.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs';
+import { AdminForemenPage } from './foremen.page';
+import { AdminApi, ApiError } from '../data-access/admin.api';
+
+describe('AdminForemenPage', () => {
+  let fixture: ComponentFixture<AdminForemenPage>;
+  let adminApi: jasmine.SpyObj<AdminApi>;
+
+  beforeEach(async () => {
+    adminApi = jasmine.createSpyObj<AdminApi>('AdminApi', [
+      'getForemen',
+      'createForeman',
+      'updateForeman',
+    ]);
+    adminApi.getForemen.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [AdminForemenPage],
+      providers: [{ provide: AdminApi, useValue: adminApi }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminForemenPage);
+    fixture.detectChanges();
+  });
+
+  it('maps validation errors to the name field', () => {
+    const validationError: ApiError = {
+      category: 'Validation',
+      message: 'Validation failed',
+      fieldErrors: { displayName: 'Name is required' },
+    };
+    adminApi.createForeman.and.returnValue(throwError(() => validationError));
+
+    fixture.componentInstance.form.controls.displayName.setValue('Foreman');
+    fixture.componentInstance.form.controls.phone.setValue('+14155550000');
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const errorElement = fixture.debugElement.query(By.css('#foreman-name-error'));
+    expect(errorElement).not.toBeNull();
+    expect(errorElement.nativeElement.textContent).toContain('Name is required');
+    expect(fixture.componentInstance.form.controls.displayName.errors?.['server']).toBe(
+      'Name is required',
+    );
+  });
+});

--- a/frontend/src/app/features/admin/pages/foremen.page.ts
+++ b/frontend/src/app/features/admin/pages/foremen.page.ts
@@ -1,7 +1,9 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AdminApi, ApiError, ForemanResponse } from '../data-access/admin.api';
 import { EmptyStateComponent } from '../../../shared/ui/empty-state/empty-state.component';
+import { ErrorBannerComponent } from '../../../shared/ui/error-banner/error-banner.component';
+import { FieldErrorComponent } from '../../../shared/ui/field-error/field-error.component';
 import { PageHeaderComponent } from '../../../shared/ui/page-header/page-header.component';
 import { LoadingSpinnerComponent } from '../../../shared/ui/loading-spinner/loading-spinner.component';
 import { StatusBadgeComponent } from '../../../shared/ui/status-badge/status-badge.component';
@@ -11,6 +13,8 @@ import { StatusBadgeComponent } from '../../../shared/ui/status-badge/status-bad
   imports: [
     ReactiveFormsModule,
     EmptyStateComponent,
+    ErrorBannerComponent,
+    FieldErrorComponent,
     PageHeaderComponent,
     LoadingSpinnerComponent,
     StatusBadgeComponent,
@@ -25,7 +29,9 @@ export class AdminForemenPage {
 
   readonly foremen = signal<ForemanResponse[]>([]);
   readonly loading = signal(false);
-  readonly error = signal<ApiError | null>(null);
+  readonly saving = signal(false);
+  readonly loadError = signal<ApiError | null>(null);
+  readonly submitError = signal<ApiError | null>(null);
   readonly editingId = signal<string | null>(null);
 
   readonly form = this.formBuilder.nonNullable.group({
@@ -35,8 +41,14 @@ export class AdminForemenPage {
   });
 
   readonly isEditing = computed(() => !!this.editingId());
+  readonly isBusy = computed(() => this.loading() || this.saving());
   readonly formTitle = computed(() => (this.isEditing() ? 'Edit foreman' : 'Add foreman'));
-  readonly submitLabel = computed(() => (this.isEditing() ? 'Save changes' : 'Add foreman'));
+  readonly submitLabel = computed(() => {
+    if (this.saving()) {
+      return this.isEditing() ? 'Saving foreman...' : 'Adding foreman...';
+    }
+    return this.isEditing() ? 'Save foreman' : 'Add foreman';
+  });
 
   constructor() {
     this.load();
@@ -44,20 +56,22 @@ export class AdminForemenPage {
 
   load(): void {
     this.loading.set(true);
-    this.error.set(null);
+    this.loadError.set(null);
     this.adminApi.getForemen().subscribe({
       next: (foremen) => {
         this.foremen.set(foremen);
         this.loading.set(false);
       },
       error: (error: ApiError) => {
-        this.error.set(error);
+        this.loadError.set(error);
         this.loading.set(false);
       },
     });
   }
 
   onEdit(foreman: ForemanResponse): void {
+    this.clearServerErrors();
+    this.submitError.set(null);
     this.editingId.set(foreman.membershipId);
     this.form.reset({
       displayName: foreman.displayName,
@@ -68,6 +82,8 @@ export class AdminForemenPage {
   }
 
   onCancelEdit(): void {
+    this.clearServerErrors();
+    this.submitError.set(null);
     this.editingId.set(null);
     this.form.reset({
       displayName: '',
@@ -82,8 +98,9 @@ export class AdminForemenPage {
       this.form.markAllAsTouched();
       return;
     }
-    this.loading.set(true);
-    this.error.set(null);
+    this.clearServerErrors();
+    this.saving.set(true);
+    this.submitError.set(null);
     const payload = this.form.getRawValue();
 
     if (this.isEditing() && this.editingId()) {
@@ -95,12 +112,15 @@ export class AdminForemenPage {
         })
         .subscribe({
           next: () => {
+            this.saving.set(false);
             this.onCancelEdit();
             this.load();
           },
           error: (error: ApiError) => {
-            this.error.set(error);
-            this.loading.set(false);
+            if (!this.applyServerErrors(error)) {
+              this.submitError.set(error);
+            }
+            this.saving.set(false);
           },
         });
       return;
@@ -114,17 +134,76 @@ export class AdminForemenPage {
       })
       .subscribe({
         next: () => {
+          this.saving.set(false);
           this.onCancelEdit();
           this.load();
         },
         error: (error: ApiError) => {
-          this.error.set(error);
-          this.loading.set(false);
+          if (!this.applyServerErrors(error)) {
+            this.submitError.set(error);
+          }
+          this.saving.set(false);
         },
       });
   }
 
   trackById(index: number, foreman: ForemanResponse): string {
     return foreman.membershipId;
+  }
+
+  nameError(): string {
+    return this.controlErrorMessage(this.form.controls.displayName, 'Name is required.');
+  }
+
+  nameErrorId(): string | null {
+    return this.nameError() ? 'foreman-name-error' : null;
+  }
+
+  phoneError(): string {
+    return this.controlErrorMessage(this.form.controls.phone, 'Phone is required.');
+  }
+
+  phoneErrorId(): string | null {
+    return this.phoneError() ? 'foreman-phone-error' : null;
+  }
+
+  private applyServerErrors(error: ApiError): boolean {
+    if (error.category !== 'Validation' || !error.fieldErrors) {
+      return false;
+    }
+    Object.entries(error.fieldErrors).forEach(([field, message]) => {
+      const control = this.form.get(field);
+      if (!control) {
+        return;
+      }
+      const existing = control.errors ?? {};
+      control.setErrors({ ...existing, server: message });
+    });
+    this.form.markAllAsTouched();
+    return true;
+  }
+
+  private clearServerErrors(): void {
+    Object.values(this.form.controls).forEach((control) => {
+      const errors = control.errors;
+      if (!errors || !('server' in errors)) {
+        return;
+      }
+      const { server, ...rest } = errors;
+      control.setErrors(Object.keys(rest).length > 0 ? rest : null);
+    });
+  }
+
+  private controlErrorMessage(control: AbstractControl, fallback: string): string {
+    if (control.errors?.['server']) {
+      return String(control.errors['server']);
+    }
+    if (!control.touched || !control.invalid) {
+      return '';
+    }
+    if (control.errors?.['required']) {
+      return fallback;
+    }
+    return fallback;
   }
 }


### PR DESCRIPTION
## Summary
- Implement admin foremen CRUD UX improvements and error handling
- Add admin foremen API coverage and UI error mapping test

## Sprint scope
- [ ] Sprint 1 only (CH-001, CH-002, CH-003)

## Validation
- [x] `scripts/lint.sh`
- [x] `scripts/test.sh`
- [x] `scripts/build.sh`
- [x] Manual smoke (admin demo login; create/edit foreman; validation; active toggle)

## Evidence
- Logs/notes: local test outputs (backend + frontend), demo seed in `.tmp/backend-dev.log`
- Screenshot(s): foremen list + edit state + validation error
- CI run link: (after CI finishes)

## Docs
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)

## Issues
Closes #9
