### PR TITLE
CH-010 Admin Workers CRUD + crew assignment

### DIFF
--- a/backend/src/main/java/com/crewhandshake/features/foreman/service/CrewCallService.java
+++ b/backend/src/main/java/com/crewhandshake/features/foreman/service/CrewCallService.java
@@ -306,7 +306,10 @@ public class CrewCallService {
                                       String token,
                                       MembershipEntity sender) {
     String baseUrl = appProperties.publicBaseUrl();
-    String link = token == null ? "" : baseUrl.replaceAll("/+$", "") + "/w/t/" + token;
+    String normalizedBaseUrl = baseUrl == null ? "" : baseUrl.trim();
+    String link = token == null || normalizedBaseUrl.isBlank()
+        ? ""
+        : normalizedBaseUrl.replaceAll("/+$", "") + "/w/t/" + token;
     String timeLabel = SMS_TIME.format(ZonedDateTime.ofInstant(startAt, DEFAULT_ZONE));
     String senderName = resolveSenderName(sender);
     StringBuilder message = new StringBuilder();

--- a/backend/src/test/java/com/crewhandshake/features/admin/AdminWorkersTest.java
+++ b/backend/src/test/java/com/crewhandshake/features/admin/AdminWorkersTest.java
@@ -1,0 +1,201 @@
+package com.crewhandshake.features.admin;
+
+import com.crewhandshake.common.security.AuthSession;
+import com.crewhandshake.common.security.MembershipRole;
+import com.crewhandshake.common.security.SessionService;
+import com.crewhandshake.features.admin.persistence.CrewEntity;
+import com.crewhandshake.features.admin.persistence.CrewRepository;
+import com.crewhandshake.features.admin.persistence.SiteEntity;
+import com.crewhandshake.features.admin.persistence.SiteRepository;
+import com.crewhandshake.features.admin.persistence.WorkerProfileEntity;
+import com.crewhandshake.features.admin.persistence.WorkerProfileRepository;
+import com.crewhandshake.features.auth.persistence.CompanyEntity;
+import com.crewhandshake.features.auth.persistence.CompanyRepository;
+import com.crewhandshake.features.auth.persistence.IdentityEntity;
+import com.crewhandshake.features.auth.persistence.IdentityRepository;
+import com.crewhandshake.features.auth.persistence.MembershipEntity;
+import com.crewhandshake.features.auth.persistence.MembershipRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AdminWorkersTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private CompanyRepository companyRepository;
+
+  @Autowired
+  private IdentityRepository identityRepository;
+
+  @Autowired
+  private MembershipRepository membershipRepository;
+
+  @Autowired
+  private WorkerProfileRepository workerProfileRepository;
+
+  @Autowired
+  private CrewRepository crewRepository;
+
+  @Autowired
+  private SiteRepository siteRepository;
+
+  @Test
+  void createWorkerRejectsInvalidPhone() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Workers Co"));
+    MembershipEntity admin = createMembership(company, Set.of(MembershipRole.ADMIN), "+14155570001");
+    MockHttpSession session = sessionFor(company, admin);
+
+    mockMvc.perform(post("/api/v1/admin/workers")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Worker\",\"phone\":\"123\"}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.fieldErrors.phone").exists());
+  }
+
+  @Test
+  void createWorkerCreatesIdentityMembershipAndProfile() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Roster Co"));
+    MembershipEntity admin = createMembership(company, Set.of(MembershipRole.ADMIN), "+14155570002");
+    MockHttpSession session = sessionFor(company, admin);
+
+    mockMvc.perform(post("/api/v1/admin/workers")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Worker One\",\"phone\":\"+14155570003\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("Worker One"));
+
+    IdentityEntity identity = identityRepository.findByPhoneE164("+14155570003").orElseThrow();
+    MembershipEntity membership = membershipRepository.findByIdentityIdAndCompanyId(identity.getId(), company.getId())
+        .orElseThrow();
+    WorkerProfileEntity worker = workerProfileRepository.findByCompanyIdAndMembershipId(company.getId(), membership.getId())
+        .orElseThrow();
+    assertTrue(membership.getRoles().contains(MembershipRole.WORKER));
+    assertTrue(worker.getCompany().getId().equals(company.getId()));
+  }
+
+  @Test
+  void duplicateWorkerMembershipReturnsConflict() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Duplicate Co"));
+    MembershipEntity admin = createMembership(company, Set.of(MembershipRole.ADMIN), "+14155570004");
+    MockHttpSession session = sessionFor(company, admin);
+
+    mockMvc.perform(post("/api/v1/admin/workers")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Worker Two\",\"phone\":\"+14155570005\"}"))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(post("/api/v1/admin/workers")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Worker Two\",\"phone\":\"+14155570005\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.errorCode").value("CONFLICT"));
+  }
+
+  @Test
+  void inactiveWorkerAssignmentIsRejected() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Inactive Co"));
+    MembershipEntity admin = createMembership(company, Set.of(MembershipRole.ADMIN), "+14155570006");
+    MembershipEntity foreman = createMembership(company, Set.of(MembershipRole.FOREMAN), "+14155570007");
+    CrewEntity crew = crewRepository.save(new CrewEntity(company, "Crew A", foreman));
+    MockHttpSession session = sessionFor(company, admin);
+
+    mockMvc.perform(post("/api/v1/admin/workers")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Worker Three\",\"phone\":\"+14155570008\",\"crewId\":\"" + crew.getId() + "\",\"active\":false}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.fieldErrors.crewId").exists());
+  }
+
+  @Test
+  void foremanCannotAccessAdminWorkers() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Foreman Blocked"));
+    MembershipEntity foreman = createMembership(company, Set.of(MembershipRole.FOREMAN), "+14155570009");
+    MockHttpSession session = sessionFor(company, foreman);
+
+    mockMvc.perform(get("/api/v1/admin/workers")
+        .session(session))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.errorCode").value("FORBIDDEN"));
+  }
+
+  @Test
+  void assignedWorkerReceivesCrewCall() throws Exception {
+    CompanyEntity company = companyRepository.save(new CompanyEntity("Crew Call Co"));
+    MembershipEntity admin = createMembership(company, Set.of(MembershipRole.ADMIN), "+14155570010");
+    MembershipEntity foreman = createMembership(company, Set.of(MembershipRole.FOREMAN), "+14155570011");
+    CrewEntity crew = crewRepository.save(new CrewEntity(company, "Crew B", foreman));
+    SiteEntity site = siteRepository.save(new SiteEntity(company, "Main Site", null, null, true));
+    MockHttpSession session = sessionFor(company, admin);
+
+    mockMvc.perform(post("/api/v1/admin/workers")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"displayName\":\"Worker Four\",\"phone\":\"+14155570012\",\"crewId\":\"" + crew.getId() + "\"}"))
+        .andExpect(status().isOk());
+
+    List<WorkerProfileEntity> workers = workerProfileRepository.findByCompanyIdAndCrewId(company.getId(), crew.getId());
+    WorkerProfileEntity worker = workers.get(0);
+
+    String startAt = Instant.now().plusSeconds(3600).toString();
+    String payload = "{\"crewId\":\"" + crew.getId() + "\",\"siteId\":\"" + site.getId() + "\",\"startAt\":\"" + startAt + "\",\"meetPoint\":\"Gate A\"}";
+
+    mockMvc.perform(post("/api/v1/foreman/crew-calls")
+        .session(session)
+        .with(csrf())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(payload))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.recipients", hasSize(1)))
+        .andExpect(jsonPath("$.recipients[0].workerMembershipId").value(worker.getMembershipId().toString()));
+  }
+
+  private MembershipEntity createMembership(CompanyEntity company, Set<MembershipRole> roles, String phone) {
+    IdentityEntity identity = identityRepository.save(new IdentityEntity(phone));
+    return membershipRepository.save(new MembershipEntity(company, identity, roles));
+  }
+
+  private MockHttpSession sessionFor(CompanyEntity company, MembershipEntity membership) {
+    AuthSession session = new AuthSession(
+        membership.getIdentity().getId(),
+        membership.getIdentity().getPhoneE164(),
+        company.getId(),
+        membership.getId(),
+        membership.getRoles()
+    );
+    MockHttpSession httpSession = new MockHttpSession();
+    httpSession.setAttribute(SessionService.SESSION_KEY, session);
+    return httpSession;
+  }
+}

--- a/frontend/src/app/features/admin/pages/workers.page.css
+++ b/frontend/src/app/features/admin/pages/workers.page.css
@@ -1,0 +1,17 @@
+.workers-active {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-1);
+}
+
+.workers-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  flex-wrap: wrap;
+}
+
+.workers-row--editing {
+  background: var(--ds-color-primary-subtle);
+}

--- a/frontend/src/app/features/admin/pages/workers.page.html
+++ b/frontend/src/app/features/admin/pages/workers.page.html
@@ -3,7 +3,7 @@
     class="ds-button ds-button--secondary"
     type="button"
     (click)="load()"
-    [disabled]="loading()"
+    [disabled]="isBusy()"
   >
     Refresh
   </button>
@@ -19,14 +19,12 @@
         class="ds-input"
         type="text"
         formControlName="displayName"
-        [class.ds-input--error]="
-          form.controls.displayName.touched && form.controls.displayName.invalid
-        "
-        aria-describedby="worker-name-error"
-        [attr.aria-invalid]="form.controls.displayName.touched && form.controls.displayName.invalid"
+        [class.ds-input--error]="!!nameError()"
+        [attr.aria-describedby]="nameErrorId()"
+        [attr.aria-invalid]="nameError() ? 'true' : null"
       />
-      @if (form.controls.displayName.touched && form.controls.displayName.invalid) {
-        <p id="worker-name-error" class="ds-error-text" role="status">Name is required.</p>
+      @if (nameError()) {
+        <app-field-error [id]="nameErrorId()" [message]="nameError()"></app-field-error>
       }
     </div>
 
@@ -39,12 +37,12 @@
           type="tel"
           formControlName="phone"
           autocomplete="tel"
-          [class.ds-input--error]="form.controls.phone.touched && form.controls.phone.invalid"
-          aria-describedby="worker-phone-error"
-          [attr.aria-invalid]="form.controls.phone.touched && form.controls.phone.invalid"
+          [class.ds-input--error]="!!phoneError()"
+          [attr.aria-describedby]="phoneErrorId()"
+          [attr.aria-invalid]="phoneError() ? 'true' : null"
         />
-        @if (form.controls.phone.touched && form.controls.phone.invalid) {
-          <p id="worker-phone-error" class="ds-error-text" role="status">Phone is required.</p>
+        @if (phoneError()) {
+          <app-field-error [id]="phoneErrorId()" [message]="phoneError()"></app-field-error>
         }
       </div>
     }
@@ -61,21 +59,41 @@
 
     <div class="ds-field">
       <label class="ds-label" for="worker-crew">Crew</label>
-      <select id="worker-crew" class="ds-select" formControlName="crewId">
+      <select
+        id="worker-crew"
+        class="ds-select"
+        formControlName="crewId"
+        [class.ds-input--error]="!!crewError()"
+        [attr.aria-describedby]="crewErrorId()"
+        [attr.aria-invalid]="crewError() ? 'true' : null"
+      >
         <option value="">Unassigned</option>
         @for (crew of crews(); track crew.crewId) {
           <option [value]="crew.crewId">{{ crew.name }}</option>
         }
       </select>
+      @if (crewError()) {
+        <app-field-error [id]="crewErrorId()" [message]="crewError()"></app-field-error>
+      }
     </div>
 
-    <label class="ds-field ds-checkbox-field">
-      <span class="ds-label">Active</span>
-      <input type="checkbox" formControlName="active" />
-    </label>
+    <div class="workers-active">
+      <label class="ds-field ds-checkbox-field" for="worker-active">
+        <span class="ds-label">Active</span>
+        <input
+          id="worker-active"
+          type="checkbox"
+          formControlName="active"
+          aria-describedby="worker-active-help"
+        />
+      </label>
+      <p class="ds-helper" id="worker-active-help">
+        Inactive workers cannot be assigned to crews or receive crew calls.
+      </p>
+    </div>
 
     <div class="ds-inline-actions">
-      <button class="ds-button ds-button--primary" type="submit" [disabled]="loading()">
+      <button class="ds-button ds-button--primary" type="submit" [disabled]="isBusy()">
         {{ submitLabel() }}
       </button>
       @if (isEditing()) {
@@ -83,7 +101,7 @@
           class="ds-button ds-button--ghost"
           type="button"
           (click)="onCancelEdit()"
-          [disabled]="loading()"
+          [disabled]="isBusy()"
         >
           Cancel
         </button>
@@ -91,10 +109,19 @@
     </div>
   </form>
 
-  @if (error()) {
-    <div class="ds-alert ds-alert--error" role="status" aria-live="polite">
-      {{ error()?.message }}
-    </div>
+  @if (submitError()) {
+    <app-error-banner
+      [message]="submitError()?.message ?? 'Something went wrong.'"
+    ></app-error-banner>
+  }
+
+  @if (loadError()) {
+    <app-error-banner
+      [message]="loadError()?.message ?? 'Unable to load workers.'"
+      [showRetry]="true"
+      retryLabel="Retry"
+      (retry)="load()"
+    ></app-error-banner>
   }
 
   @if (loading()) {
@@ -103,10 +130,12 @@
     </div>
   } @else {
     @if (workers().length === 0) {
-      <app-empty-state
-        title="No workers yet"
-        description="Add a worker to start building your roster."
-      ></app-empty-state>
+      @if (!loadError()) {
+        <app-empty-state
+          title="No workers yet"
+          description="Add a worker to start building your roster."
+        ></app-empty-state>
+      }
     } @else {
       <div class="ds-table-wrap">
         <table class="ds-table" aria-label="Workers">
@@ -121,7 +150,7 @@
           </thead>
           <tbody>
             @for (worker of workers(); track trackById($index, worker)) {
-              <tr>
+              <tr [class.workers-row--editing]="editingId() === worker.membershipId">
                 <td>{{ worker.displayName }}</td>
                 <td>{{ worker.phoneE164 }}</td>
                 <td>{{ worker.crewName || 'Unassigned' }}</td>
@@ -132,9 +161,19 @@
                   ></app-status-badge>
                 </td>
                 <td>
-                  <button class="ds-button ds-button--ghost" type="button" (click)="onEdit(worker)">
-                    Edit
-                  </button>
+                  <div class="workers-actions">
+                    @if (editingId() === worker.membershipId) {
+                      <span class="ds-chip">Editing</span>
+                    }
+                    <button
+                      class="ds-button ds-button--ghost"
+                      type="button"
+                      (click)="onEdit(worker)"
+                      [attr.aria-label]="'Edit worker ' + worker.displayName"
+                    >
+                      Edit
+                    </button>
+                  </div>
                 </td>
               </tr>
             }

--- a/frontend/src/app/features/admin/pages/workers.page.spec.ts
+++ b/frontend/src/app/features/admin/pages/workers.page.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs';
+import { AdminWorkersPage } from './workers.page';
+import { AdminApi, ApiError } from '../data-access/admin.api';
+
+describe('AdminWorkersPage', () => {
+  let fixture: ComponentFixture<AdminWorkersPage>;
+  let adminApi: jasmine.SpyObj<AdminApi>;
+
+  beforeEach(async () => {
+    adminApi = jasmine.createSpyObj<AdminApi>('AdminApi', [
+      'getWorkers',
+      'getCrews',
+      'createWorker',
+      'updateWorker',
+    ]);
+    adminApi.getWorkers.and.returnValue(of([]));
+    adminApi.getCrews.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [AdminWorkersPage],
+      providers: [{ provide: AdminApi, useValue: adminApi }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminWorkersPage);
+    fixture.detectChanges();
+  });
+
+  it('maps validation errors to the crew field', () => {
+    const validationError: ApiError = {
+      category: 'Validation',
+      message: 'Validation failed',
+      fieldErrors: { crewId: 'Worker must be active to assign to a crew' },
+    };
+    adminApi.createWorker.and.returnValue(throwError(() => validationError));
+
+    fixture.componentInstance.form.controls.displayName.setValue('Worker');
+    fixture.componentInstance.form.controls.phone.setValue('+14155550000');
+    fixture.componentInstance.form.controls.crewId.setValue('crew-1');
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const errorElement = fixture.debugElement.query(By.css('#worker-crew-error'));
+    expect(errorElement).not.toBeNull();
+    expect(errorElement.nativeElement.textContent).toContain(
+      'Worker must be active to assign to a crew',
+    );
+    expect(fixture.componentInstance.form.controls.crewId.errors?.['server']).toBe(
+      'Worker must be active to assign to a crew',
+    );
+  });
+});

--- a/frontend/src/app/features/admin/pages/workers.page.ts
+++ b/frontend/src/app/features/admin/pages/workers.page.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { forkJoin } from 'rxjs';
 import { AdminApi, ApiError, CrewResponse, WorkerResponse } from '../data-access/admin.api';
 import { EmptyStateComponent } from '../../../shared/ui/empty-state/empty-state.component';
+import { ErrorBannerComponent } from '../../../shared/ui/error-banner/error-banner.component';
+import { FieldErrorComponent } from '../../../shared/ui/field-error/field-error.component';
 import { PageHeaderComponent } from '../../../shared/ui/page-header/page-header.component';
 import { LoadingSpinnerComponent } from '../../../shared/ui/loading-spinner/loading-spinner.component';
 import { StatusBadgeComponent } from '../../../shared/ui/status-badge/status-badge.component';
@@ -12,6 +14,8 @@ import { StatusBadgeComponent } from '../../../shared/ui/status-badge/status-bad
   imports: [
     ReactiveFormsModule,
     EmptyStateComponent,
+    ErrorBannerComponent,
+    FieldErrorComponent,
     PageHeaderComponent,
     LoadingSpinnerComponent,
     StatusBadgeComponent,
@@ -27,7 +31,9 @@ export class AdminWorkersPage {
   readonly workers = signal<WorkerResponse[]>([]);
   readonly crews = signal<CrewResponse[]>([]);
   readonly loading = signal(false);
-  readonly error = signal<ApiError | null>(null);
+  readonly saving = signal(false);
+  readonly loadError = signal<ApiError | null>(null);
+  readonly submitError = signal<ApiError | null>(null);
   readonly editingId = signal<string | null>(null);
 
   readonly form = this.formBuilder.nonNullable.group({
@@ -39,8 +45,14 @@ export class AdminWorkersPage {
   });
 
   readonly isEditing = computed(() => !!this.editingId());
+  readonly isBusy = computed(() => this.loading() || this.saving());
   readonly formTitle = computed(() => (this.isEditing() ? 'Edit worker' : 'Add worker'));
-  readonly submitLabel = computed(() => (this.isEditing() ? 'Save changes' : 'Add worker'));
+  readonly submitLabel = computed(() => {
+    if (this.saving()) {
+      return this.isEditing() ? 'Saving worker...' : 'Adding worker...';
+    }
+    return this.isEditing() ? 'Save worker' : 'Add worker';
+  });
 
   constructor() {
     this.load();
@@ -48,7 +60,8 @@ export class AdminWorkersPage {
 
   load(): void {
     this.loading.set(true);
-    this.error.set(null);
+    this.loadError.set(null);
+    this.submitError.set(null);
     forkJoin({
       workers: this.adminApi.getWorkers(),
       crews: this.adminApi.getCrews(),
@@ -59,13 +72,15 @@ export class AdminWorkersPage {
         this.loading.set(false);
       },
       error: (error: ApiError) => {
-        this.error.set(error);
+        this.loadError.set(error);
         this.loading.set(false);
       },
     });
   }
 
   onEdit(worker: WorkerResponse): void {
+    this.clearServerErrors();
+    this.submitError.set(null);
     this.editingId.set(worker.membershipId);
     this.form.reset({
       displayName: worker.displayName,
@@ -78,6 +93,8 @@ export class AdminWorkersPage {
   }
 
   onCancelEdit(): void {
+    this.clearServerErrors();
+    this.submitError.set(null);
     this.editingId.set(null);
     this.form.reset({
       displayName: '',
@@ -94,8 +111,9 @@ export class AdminWorkersPage {
       this.form.markAllAsTouched();
       return;
     }
-    this.loading.set(true);
-    this.error.set(null);
+    this.clearServerErrors();
+    this.saving.set(true);
+    this.submitError.set(null);
     const payload = this.form.getRawValue();
     const crewId = payload.crewId ? payload.crewId : null;
 
@@ -110,12 +128,15 @@ export class AdminWorkersPage {
         })
         .subscribe({
           next: () => {
+            this.saving.set(false);
             this.onCancelEdit();
             this.load();
           },
           error: (error: ApiError) => {
-            this.error.set(error);
-            this.loading.set(false);
+            if (!this.applyServerErrors(error)) {
+              this.submitError.set(error);
+            }
+            this.saving.set(false);
           },
         });
       return;
@@ -131,17 +152,84 @@ export class AdminWorkersPage {
       })
       .subscribe({
         next: () => {
+          this.saving.set(false);
           this.onCancelEdit();
           this.load();
         },
         error: (error: ApiError) => {
-          this.error.set(error);
-          this.loading.set(false);
+          if (!this.applyServerErrors(error)) {
+            this.submitError.set(error);
+          }
+          this.saving.set(false);
         },
       });
   }
 
   trackById(index: number, worker: WorkerResponse): string {
     return worker.membershipId;
+  }
+
+  nameError(): string {
+    return this.controlErrorMessage(this.form.controls.displayName, 'Name is required.');
+  }
+
+  nameErrorId(): string | null {
+    return this.nameError() ? 'worker-name-error' : null;
+  }
+
+  phoneError(): string {
+    return this.controlErrorMessage(this.form.controls.phone, 'Phone is required.');
+  }
+
+  phoneErrorId(): string | null {
+    return this.phoneError() ? 'worker-phone-error' : null;
+  }
+
+  crewError(): string {
+    return this.controlErrorMessage(this.form.controls.crewId, '');
+  }
+
+  crewErrorId(): string | null {
+    return this.crewError() ? 'worker-crew-error' : null;
+  }
+
+  private applyServerErrors(error: ApiError): boolean {
+    if (error.category !== 'Validation' || !error.fieldErrors) {
+      return false;
+    }
+    Object.entries(error.fieldErrors).forEach(([field, message]) => {
+      const control = this.form.get(field);
+      if (!control) {
+        return;
+      }
+      const existing = control.errors ?? {};
+      control.setErrors({ ...existing, server: message });
+    });
+    this.form.markAllAsTouched();
+    return true;
+  }
+
+  private clearServerErrors(): void {
+    Object.values(this.form.controls).forEach((control) => {
+      const errors = control.errors;
+      if (!errors || !('server' in errors)) {
+        return;
+      }
+      const { server, ...rest } = errors;
+      control.setErrors(Object.keys(rest).length > 0 ? rest : null);
+    });
+  }
+
+  private controlErrorMessage(control: AbstractControl, fallback: string): string {
+    if (control.errors?.['server']) {
+      return String(control.errors['server']);
+    }
+    if (!control.touched || !control.invalid) {
+      return '';
+    }
+    if (control.errors?.['required']) {
+      return fallback;
+    }
+    return fallback;
   }
 }


### PR DESCRIPTION
## Summary
- Improve admin workers CRUD UX with server-side validation mapping, split load/submit errors, and editing affordances
- Add integration tests for worker creation constraints and crew call recipient inclusion
- Harden crew call SMS link building when public base URL is missing

## Sprint scope
- [ ] Sprint 1 only (CH-001, CH-002, CH-003)

## Validation
- [x] `scripts/lint.sh`
- [x] `scripts/test.sh`
- [x] `scripts/build.sh`
- [ ] Manual smoke (admin login; create/edit worker; crew assignment; inactive validation; crew call recipient)

## Evidence
- Logs/notes: local test output (backend + frontend)
- Screenshot(s): workers list + edit state + validation error
- CI run link: (after CI finishes)

## Docs
- [ ] README updated (if needed)
- [ ] Docs updated (if needed)

## Issues
Closes #10
