### PR TITLE
Admin mobile nav + responsive roster lists

### DIFF
--- a/frontend/src/app/core/ui/admin-shell/admin-shell.component.css
+++ b/frontend/src/app/core/ui/admin-shell/admin-shell.component.css
@@ -13,6 +13,14 @@
   gap: var(--ds-space-3);
 }
 
+.shell__top {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-space-2);
+}
+
 .shell__brand {
   font-size: var(--ds-font-size-h3);
   line-height: var(--ds-line-height-h3);
@@ -20,13 +28,25 @@
   color: var(--ds-color-text);
 }
 
+.shell__menu {
+  width: 100%;
+  display: none;
+  flex-direction: column;
+  gap: var(--ds-space-3);
+  padding-top: var(--ds-space-3);
+  border-top: 1px solid var(--ds-color-border);
+}
+
+.shell__menu--open {
+  display: flex;
+}
+
 .shell__nav {
   display: flex;
   gap: var(--ds-space-2);
+  flex-direction: column;
   flex-wrap: nowrap;
   width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .shell__spacer {
@@ -50,10 +70,21 @@
   color: var(--ds-color-text-secondary);
   font-weight: var(--ds-font-weight-medium);
   white-space: nowrap;
+  width: 100%;
 }
 
 .shell__link:hover {
   background: var(--ds-color-bg-subtle);
+}
+
+.shell__link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--ds-color-focus-ring);
+}
+
+.shell__menu-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--ds-color-focus-ring);
 }
 
 .shell__link--active {
@@ -68,10 +99,29 @@
     gap: var(--ds-space-4);
   }
 
+  .shell__top {
+    width: auto;
+  }
+
+  .shell__menu {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--ds-space-4);
+    padding-top: 0;
+    border-top: none;
+    width: auto;
+    flex: 1 1 auto;
+  }
+
+  .shell__menu-toggle {
+    display: none;
+  }
+
   .shell__nav {
+    flex-direction: row;
     flex-wrap: wrap;
     width: auto;
-    overflow: visible;
   }
 
   .shell__spacer {
@@ -79,6 +129,10 @@
   }
 
   .shell__actions {
+    width: auto;
+  }
+
+  .shell__link {
     width: auto;
   }
 }

--- a/frontend/src/app/core/ui/admin-shell/admin-shell.component.html
+++ b/frontend/src/app/core/ui/admin-shell/admin-shell.component.html
@@ -2,43 +2,88 @@
   <a class="ds-skip-link" href="#main">Skip to content</a>
   <header class="shell">
     <div class="shell__inner">
-      <div class="shell__brand">Crew Handshake</div>
-      <nav class="shell__nav" aria-label="Admin">
-        <a class="shell__link" routerLink="/a/workers" routerLinkActive="shell__link--active"
-          >Workers</a
-        >
-        <a class="shell__link" routerLink="/a/foremen" routerLinkActive="shell__link--active"
-          >Foremen</a
-        >
-        <a class="shell__link" routerLink="/a/crews" routerLinkActive="shell__link--active"
-          >Crews</a
-        >
-        <a class="shell__link" routerLink="/a/sites" routerLinkActive="shell__link--active"
-          >Sites</a
-        >
-        <a class="shell__link" routerLink="/a/settings" routerLinkActive="shell__link--active"
-          >Settings</a
-        >
-        <a class="shell__link" routerLink="/a/exceptions" routerLinkActive="shell__link--active"
-          >Exceptions</a
-        >
-        <a class="shell__link" routerLink="/a/payroll" routerLinkActive="shell__link--active"
-          >Payroll</a
-        >
-        <a class="shell__link" routerLink="/a/audit" routerLinkActive="shell__link--active"
-          >Audit</a
-        >
-      </nav>
-      <div class="shell__spacer"></div>
-      <div class="shell__actions">
+      <div class="shell__top">
+        <div class="shell__brand">Crew Handshake</div>
         <button
-          class="ds-button ds-button--ghost"
+          class="ds-button ds-button--secondary shell__menu-toggle"
           type="button"
-          (click)="logout()"
-          [disabled]="isLoggingOut"
+          (click)="toggleMenu()"
+          aria-controls="admin-nav"
+          [attr.aria-expanded]="menuOpen() ? 'true' : 'false'"
         >
-          Log out
+          {{ menuOpen() ? 'Close menu' : 'Menu' }}
         </button>
+      </div>
+      <div class="shell__menu" [class.shell__menu--open]="menuOpen()">
+        <nav id="admin-nav" class="shell__nav" aria-label="Admin">
+          <a
+            class="shell__link"
+            routerLink="/a/workers"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Workers</a
+          >
+          <a
+            class="shell__link"
+            routerLink="/a/foremen"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Foremen</a
+          >
+          <a
+            class="shell__link"
+            routerLink="/a/crews"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Crews</a
+          >
+          <a
+            class="shell__link"
+            routerLink="/a/sites"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Sites</a
+          >
+          <a
+            class="shell__link"
+            routerLink="/a/settings"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Settings</a
+          >
+          <a
+            class="shell__link"
+            routerLink="/a/exceptions"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Exceptions</a
+          >
+          <a
+            class="shell__link"
+            routerLink="/a/payroll"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Payroll</a
+          >
+          <a
+            class="shell__link"
+            routerLink="/a/audit"
+            routerLinkActive="shell__link--active"
+            (click)="closeMenu()"
+            >Audit</a
+          >
+        </nav>
+        <div class="shell__spacer"></div>
+        <div class="shell__actions">
+          <button
+            class="ds-button ds-button--ghost"
+            type="button"
+            (click)="logout()"
+            [disabled]="isLoggingOut"
+          >
+            Log out
+          </button>
+        </div>
       </div>
     </div>
   </header>

--- a/frontend/src/app/core/ui/admin-shell/admin-shell.component.ts
+++ b/frontend/src/app/core/ui/admin-shell/admin-shell.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { AuthSessionService } from '../../auth/auth-session.service';
 
@@ -15,16 +15,27 @@ import { AuthSessionService } from '../../auth/auth-session.service';
 export class AdminShellComponent {
   private readonly session = inject(AuthSessionService);
   private readonly router = inject(Router);
+  readonly menuOpen = signal(false);
 
   logout(): void {
     this.session.logout().subscribe({
       next: () => {
+        this.menuOpen.set(false);
         this.router.navigate(['/auth']);
       },
       error: () => {
+        this.menuOpen.set(false);
         this.router.navigate(['/auth']);
       },
     });
+  }
+
+  toggleMenu(): void {
+    this.menuOpen.update((open) => !open);
+  }
+
+  closeMenu(): void {
+    this.menuOpen.set(false);
   }
 
   get isLoggingOut(): boolean {

--- a/frontend/src/app/features/admin/pages/crews.page.css
+++ b/frontend/src/app/features/admin/pages/crews.page.css
@@ -36,3 +36,51 @@
 .worker-option input {
   margin: 0;
 }
+
+.crews-list {
+  display: block;
+}
+
+.crews-table {
+  display: none;
+}
+
+.crews-name {
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-text);
+}
+
+.crews-count {
+  font-size: var(--ds-font-size-small);
+  color: var(--ds-color-text-secondary);
+}
+
+.crews-meta {
+  display: grid;
+  gap: var(--ds-space-1);
+  font-size: var(--ds-font-size-small);
+  color: var(--ds-color-text-secondary);
+}
+
+.crews-meta__label {
+  color: var(--ds-color-text-muted);
+  font-weight: var(--ds-font-weight-medium);
+}
+
+.crews-list__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  flex-wrap: wrap;
+}
+
+@media (min-width: 768px) {
+  .crews-list {
+    display: none;
+  }
+
+  .crews-table {
+    display: block;
+  }
+}

--- a/frontend/src/app/features/admin/pages/crews.page.html
+++ b/frontend/src/app/features/admin/pages/crews.page.html
@@ -102,31 +102,56 @@
         description="Create a crew and assign its roster."
       ></app-empty-state>
     } @else {
-      <div class="ds-table-wrap">
-        <table class="ds-table" aria-label="Crews">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Foreman</th>
-              <th>Workers</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (crew of crews(); track trackCrew($index, crew)) {
+      <div class="crews-list">
+        <ul class="ds-list" role="list" aria-label="Crews">
+          @for (crew of crews(); track trackCrew($index, crew)) {
+            <li class="ds-list__item">
+              <div class="ds-list__row">
+                <div class="crews-name">{{ crew.name }}</div>
+                <div class="crews-count">{{ crew.workerCount }} workers</div>
+              </div>
+              <div class="crews-meta">
+                <div class="crews-meta__item">
+                  <span class="crews-meta__label">Foreman</span>
+                  <span>{{ crew.foremanName }}</span>
+                </div>
+              </div>
+              <div class="crews-list__actions">
+                <button class="ds-button ds-button--ghost" type="button" (click)="onEdit(crew)">
+                  Edit
+                </button>
+              </div>
+            </li>
+          }
+        </ul>
+      </div>
+      <div class="crews-table">
+        <div class="ds-table-wrap">
+          <table class="ds-table" aria-label="Crews">
+            <thead>
               <tr>
-                <td>{{ crew.name }}</td>
-                <td>{{ crew.foremanName }}</td>
-                <td>{{ crew.workerCount }}</td>
-                <td>
-                  <button class="ds-button ds-button--ghost" type="button" (click)="onEdit(crew)">
-                    Edit
-                  </button>
-                </td>
+                <th>Name</th>
+                <th>Foreman</th>
+                <th>Workers</th>
+                <th></th>
               </tr>
-            }
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              @for (crew of crews(); track trackCrew($index, crew)) {
+                <tr>
+                  <td>{{ crew.name }}</td>
+                  <td>{{ crew.foremanName }}</td>
+                  <td>{{ crew.workerCount }}</td>
+                  <td>
+                    <button class="ds-button ds-button--ghost" type="button" (click)="onEdit(crew)">
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
       </div>
     }
   }

--- a/frontend/src/app/features/admin/pages/foremen.page.css
+++ b/frontend/src/app/features/admin/pages/foremen.page.css
@@ -4,6 +4,39 @@
   gap: var(--ds-space-1);
 }
 
+.foremen-list {
+  display: block;
+}
+
+.foremen-table {
+  display: none;
+}
+
+.foremen-name {
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-text);
+}
+
+.foremen-meta {
+  display: grid;
+  gap: var(--ds-space-1);
+  font-size: var(--ds-font-size-small);
+  color: var(--ds-color-text-secondary);
+}
+
+.foremen-meta__label {
+  color: var(--ds-color-text-muted);
+  font-weight: var(--ds-font-weight-medium);
+}
+
+.foremen-list__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  flex-wrap: wrap;
+}
+
 .foremen-actions {
   display: flex;
   align-items: center;
@@ -14,4 +47,18 @@
 
 .foremen-row--editing {
   background: var(--ds-color-primary-subtle);
+}
+
+.foremen-item--editing {
+  background: var(--ds-color-primary-subtle);
+}
+
+@media (min-width: 768px) {
+  .foremen-list {
+    display: none;
+  }
+
+  .foremen-table {
+    display: block;
+  }
 }

--- a/frontend/src/app/features/admin/pages/foremen.page.html
+++ b/frontend/src/app/features/admin/pages/foremen.page.html
@@ -107,46 +107,85 @@
         ></app-empty-state>
       }
     } @else {
-      <div class="ds-table-wrap">
-        <table class="ds-table" aria-label="Foremen">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Phone</th>
-              <th>Status</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (foreman of foremen(); track trackById($index, foreman)) {
-              <tr [class.foremen-row--editing]="editingId() === foreman.membershipId">
-                <td>{{ foreman.displayName }}</td>
-                <td>{{ foreman.phoneE164 }}</td>
-                <td>
-                  <app-status-badge
-                    [tone]="foreman.active ? 'success' : 'warning'"
-                    [label]="foreman.active ? 'Active' : 'Inactive'"
-                  ></app-status-badge>
-                </td>
-                <td>
-                  <div class="foremen-actions">
-                    @if (editingId() === foreman.membershipId) {
-                      <span class="ds-chip">Editing</span>
-                    }
-                    <button
-                      class="ds-button ds-button--ghost"
-                      type="button"
-                      (click)="onEdit(foreman)"
-                      [attr.aria-label]="'Edit foreman ' + foreman.displayName"
-                    >
-                      Edit
-                    </button>
-                  </div>
-                </td>
+      <div class="foremen-list">
+        <ul class="ds-list" role="list" aria-label="Foremen">
+          @for (foreman of foremen(); track trackById($index, foreman)) {
+            <li
+              class="ds-list__item"
+              [class.foremen-item--editing]="editingId() === foreman.membershipId"
+            >
+              <div class="ds-list__row">
+                <div class="foremen-name">{{ foreman.displayName }}</div>
+                <app-status-badge
+                  [tone]="foreman.active ? 'success' : 'warning'"
+                  [label]="foreman.active ? 'Active' : 'Inactive'"
+                ></app-status-badge>
+              </div>
+              <div class="foremen-meta">
+                <div class="foremen-meta__item">
+                  <span class="foremen-meta__label">Phone</span>
+                  <span>{{ foreman.phoneE164 }}</span>
+                </div>
+              </div>
+              <div class="foremen-list__actions">
+                @if (editingId() === foreman.membershipId) {
+                  <span class="ds-chip">Editing</span>
+                }
+                <button
+                  class="ds-button ds-button--ghost"
+                  type="button"
+                  (click)="onEdit(foreman)"
+                  [attr.aria-label]="'Edit foreman ' + foreman.displayName"
+                >
+                  Edit
+                </button>
+              </div>
+            </li>
+          }
+        </ul>
+      </div>
+      <div class="foremen-table">
+        <div class="ds-table-wrap">
+          <table class="ds-table" aria-label="Foremen">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Phone</th>
+                <th>Status</th>
+                <th></th>
               </tr>
-            }
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              @for (foreman of foremen(); track trackById($index, foreman)) {
+                <tr [class.foremen-row--editing]="editingId() === foreman.membershipId">
+                  <td>{{ foreman.displayName }}</td>
+                  <td>{{ foreman.phoneE164 }}</td>
+                  <td>
+                    <app-status-badge
+                      [tone]="foreman.active ? 'success' : 'warning'"
+                      [label]="foreman.active ? 'Active' : 'Inactive'"
+                    ></app-status-badge>
+                  </td>
+                  <td>
+                    <div class="foremen-actions">
+                      @if (editingId() === foreman.membershipId) {
+                        <span class="ds-chip">Editing</span>
+                      }
+                      <button
+                        class="ds-button ds-button--ghost"
+                        type="button"
+                        (click)="onEdit(foreman)"
+                        [attr.aria-label]="'Edit foreman ' + foreman.displayName"
+                      >
+                        Edit
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
       </div>
     }
   }

--- a/frontend/src/app/features/admin/pages/sites.page.css
+++ b/frontend/src/app/features/admin/pages/sites.page.css
@@ -4,6 +4,39 @@
   gap: var(--ds-space-1);
 }
 
+.sites-list {
+  display: block;
+}
+
+.sites-table {
+  display: none;
+}
+
+.sites-name {
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-text);
+}
+
+.sites-meta {
+  display: grid;
+  gap: var(--ds-space-1);
+  font-size: var(--ds-font-size-small);
+  color: var(--ds-color-text-secondary);
+}
+
+.sites-meta__label {
+  color: var(--ds-color-text-muted);
+  font-weight: var(--ds-font-weight-medium);
+}
+
+.sites-list__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  flex-wrap: wrap;
+}
+
 .sites-actions {
   display: flex;
   align-items: center;
@@ -14,4 +47,18 @@
 
 .sites-row--editing {
   background: var(--ds-color-primary-subtle);
+}
+
+.sites-item--editing {
+  background: var(--ds-color-primary-subtle);
+}
+
+@media (min-width: 768px) {
+  .sites-list {
+    display: none;
+  }
+
+  .sites-table {
+    display: block;
+  }
 }

--- a/frontend/src/app/features/admin/pages/sites.page.html
+++ b/frontend/src/app/features/admin/pages/sites.page.html
@@ -98,46 +98,82 @@
         ></app-empty-state>
       }
     } @else {
-      <div class="ds-table-wrap">
-        <table class="ds-table" aria-label="Sites">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Address</th>
-              <th>Status</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (site of sites(); track trackById($index, site)) {
-              <tr [class.sites-row--editing]="editingId() === site.siteId">
-                <td>{{ site.name }}</td>
-                <td>{{ site.address || 'N/A' }}</td>
-                <td>
-                  <app-status-badge
-                    [tone]="site.active ? 'success' : 'warning'"
-                    [label]="site.active ? 'Active' : 'Inactive'"
-                  ></app-status-badge>
-                </td>
-                <td>
-                  <div class="sites-actions">
-                    @if (editingId() === site.siteId) {
-                      <span class="ds-chip">Editing</span>
-                    }
-                    <button
-                      class="ds-button ds-button--ghost"
-                      type="button"
-                      (click)="onEdit(site)"
-                      [attr.aria-label]="'Edit site ' + site.name"
-                    >
-                      Edit
-                    </button>
-                  </div>
-                </td>
+      <div class="sites-list">
+        <ul class="ds-list" role="list" aria-label="Sites">
+          @for (site of sites(); track trackById($index, site)) {
+            <li class="ds-list__item" [class.sites-item--editing]="editingId() === site.siteId">
+              <div class="ds-list__row">
+                <div class="sites-name">{{ site.name }}</div>
+                <app-status-badge
+                  [tone]="site.active ? 'success' : 'warning'"
+                  [label]="site.active ? 'Active' : 'Inactive'"
+                ></app-status-badge>
+              </div>
+              <div class="sites-meta">
+                <div class="sites-meta__item">
+                  <span class="sites-meta__label">Address</span>
+                  <span>{{ site.address || 'N/A' }}</span>
+                </div>
+              </div>
+              <div class="sites-list__actions">
+                @if (editingId() === site.siteId) {
+                  <span class="ds-chip">Editing</span>
+                }
+                <button
+                  class="ds-button ds-button--ghost"
+                  type="button"
+                  (click)="onEdit(site)"
+                  [attr.aria-label]="'Edit site ' + site.name"
+                >
+                  Edit
+                </button>
+              </div>
+            </li>
+          }
+        </ul>
+      </div>
+      <div class="sites-table">
+        <div class="ds-table-wrap">
+          <table class="ds-table" aria-label="Sites">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Address</th>
+                <th>Status</th>
+                <th></th>
               </tr>
-            }
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              @for (site of sites(); track trackById($index, site)) {
+                <tr [class.sites-row--editing]="editingId() === site.siteId">
+                  <td>{{ site.name }}</td>
+                  <td>{{ site.address || 'N/A' }}</td>
+                  <td>
+                    <app-status-badge
+                      [tone]="site.active ? 'success' : 'warning'"
+                      [label]="site.active ? 'Active' : 'Inactive'"
+                    ></app-status-badge>
+                  </td>
+                  <td>
+                    <div class="sites-actions">
+                      @if (editingId() === site.siteId) {
+                        <span class="ds-chip">Editing</span>
+                      }
+                      <button
+                        class="ds-button ds-button--ghost"
+                        type="button"
+                        (click)="onEdit(site)"
+                        [attr.aria-label]="'Edit site ' + site.name"
+                      >
+                        Edit
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
       </div>
     }
   }

--- a/frontend/src/app/features/admin/pages/workers.page.css
+++ b/frontend/src/app/features/admin/pages/workers.page.css
@@ -4,6 +4,39 @@
   gap: var(--ds-space-1);
 }
 
+.workers-list {
+  display: block;
+}
+
+.workers-table {
+  display: none;
+}
+
+.workers-name {
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-text);
+}
+
+.workers-meta {
+  display: grid;
+  gap: var(--ds-space-1);
+  font-size: var(--ds-font-size-small);
+  color: var(--ds-color-text-secondary);
+}
+
+.workers-meta__label {
+  color: var(--ds-color-text-muted);
+  font-weight: var(--ds-font-weight-medium);
+}
+
+.workers-list__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--ds-space-2);
+  flex-wrap: wrap;
+}
+
 .workers-actions {
   display: flex;
   align-items: center;
@@ -14,4 +47,18 @@
 
 .workers-row--editing {
   background: var(--ds-color-primary-subtle);
+}
+
+.workers-item--editing {
+  background: var(--ds-color-primary-subtle);
+}
+
+@media (min-width: 768px) {
+  .workers-list {
+    display: none;
+  }
+
+  .workers-table {
+    display: block;
+  }
 }

--- a/frontend/src/app/features/admin/pages/workers.page.html
+++ b/frontend/src/app/features/admin/pages/workers.page.html
@@ -137,48 +137,91 @@
         ></app-empty-state>
       }
     } @else {
-      <div class="ds-table-wrap">
-        <table class="ds-table" aria-label="Workers">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Phone</th>
-              <th>Crew</th>
-              <th>Status</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (worker of workers(); track trackById($index, worker)) {
-              <tr [class.workers-row--editing]="editingId() === worker.membershipId">
-                <td>{{ worker.displayName }}</td>
-                <td>{{ worker.phoneE164 }}</td>
-                <td>{{ worker.crewName || 'Unassigned' }}</td>
-                <td>
-                  <app-status-badge
-                    [tone]="worker.active ? 'success' : 'warning'"
-                    [label]="worker.active ? 'Active' : 'Inactive'"
-                  ></app-status-badge>
-                </td>
-                <td>
-                  <div class="workers-actions">
-                    @if (editingId() === worker.membershipId) {
-                      <span class="ds-chip">Editing</span>
-                    }
-                    <button
-                      class="ds-button ds-button--ghost"
-                      type="button"
-                      (click)="onEdit(worker)"
-                      [attr.aria-label]="'Edit worker ' + worker.displayName"
-                    >
-                      Edit
-                    </button>
-                  </div>
-                </td>
+      <div class="workers-list">
+        <ul class="ds-list" role="list" aria-label="Workers">
+          @for (worker of workers(); track trackById($index, worker)) {
+            <li
+              class="ds-list__item"
+              [class.workers-item--editing]="editingId() === worker.membershipId"
+            >
+              <div class="ds-list__row">
+                <div class="workers-name">{{ worker.displayName }}</div>
+                <app-status-badge
+                  [tone]="worker.active ? 'success' : 'warning'"
+                  [label]="worker.active ? 'Active' : 'Inactive'"
+                ></app-status-badge>
+              </div>
+              <div class="workers-meta">
+                <div class="workers-meta__item">
+                  <span class="workers-meta__label">Phone</span>
+                  <span>{{ worker.phoneE164 }}</span>
+                </div>
+                <div class="workers-meta__item">
+                  <span class="workers-meta__label">Crew</span>
+                  <span>{{ worker.crewName || 'Unassigned' }}</span>
+                </div>
+              </div>
+              <div class="workers-list__actions">
+                @if (editingId() === worker.membershipId) {
+                  <span class="ds-chip">Editing</span>
+                }
+                <button
+                  class="ds-button ds-button--ghost"
+                  type="button"
+                  (click)="onEdit(worker)"
+                  [attr.aria-label]="'Edit worker ' + worker.displayName"
+                >
+                  Edit
+                </button>
+              </div>
+            </li>
+          }
+        </ul>
+      </div>
+      <div class="workers-table">
+        <div class="ds-table-wrap">
+          <table class="ds-table" aria-label="Workers">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Phone</th>
+                <th>Crew</th>
+                <th>Status</th>
+                <th></th>
               </tr>
-            }
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              @for (worker of workers(); track trackById($index, worker)) {
+                <tr [class.workers-row--editing]="editingId() === worker.membershipId">
+                  <td>{{ worker.displayName }}</td>
+                  <td>{{ worker.phoneE164 }}</td>
+                  <td>{{ worker.crewName || 'Unassigned' }}</td>
+                  <td>
+                    <app-status-badge
+                      [tone]="worker.active ? 'success' : 'warning'"
+                      [label]="worker.active ? 'Active' : 'Inactive'"
+                    ></app-status-badge>
+                  </td>
+                  <td>
+                    <div class="workers-actions">
+                      @if (editingId() === worker.membershipId) {
+                        <span class="ds-chip">Editing</span>
+                      }
+                      <button
+                        class="ds-button ds-button--ghost"
+                        type="button"
+                        (click)="onEdit(worker)"
+                        [attr.aria-label]="'Edit worker ' + worker.displayName"
+                      >
+                        Edit
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
       </div>
     }
   }


### PR DESCRIPTION
## Summary
- add collapsible mobile admin nav with accessible toggle and focus styles
- add responsive list layouts for workers/foremen/crews/sites; tables remain for desktop
- preserve edit chips/actions in list view

## Testing
- npm run lint (frontend)
- npm run build (frontend)
- npm run test -- --watch=false (frontend)

## Manual QA
- Not run (UI check needed in browser)

Closes #45