### PR TITLE
Foreman Exceptions responsive list view

### DIFF
--- a/frontend/src/app/features/foreman/pages/exceptions.page.css
+++ b/frontend/src/app/features/foreman/pages/exceptions.page.css
@@ -1,0 +1,34 @@
+.foreman-exceptions-list {
+  display: block;
+}
+
+.foreman-exceptions-table {
+  display: none;
+}
+
+.foreman-exceptions-worker {
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-text);
+}
+
+.foreman-exceptions-meta {
+  display: grid;
+  gap: var(--ds-space-1);
+  font-size: var(--ds-font-size-small);
+  color: var(--ds-color-text-secondary);
+}
+
+.foreman-exceptions-meta__label {
+  color: var(--ds-color-text-muted);
+  font-weight: var(--ds-font-weight-medium);
+}
+
+@media (min-width: 768px) {
+  .foreman-exceptions-list {
+    display: none;
+  }
+
+  .foreman-exceptions-table {
+    display: block;
+  }
+}

--- a/frontend/src/app/features/foreman/pages/exceptions.page.html
+++ b/frontend/src/app/features/foreman/pages/exceptions.page.html
@@ -53,35 +53,65 @@
         description="This crew has no open exceptions for the selected date."
       ></app-empty-state>
     } @else {
-      <div class="ds-table-wrap">
-        <table class="ds-table" aria-label="Exceptions">
-          <thead>
-            <tr>
-              <th>Worker</th>
-              <th>Type</th>
-              <th>Details</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (item of exceptions(); track item.exceptionId) {
+      <div class="foreman-exceptions-list">
+        <ul class="ds-list" role="list" aria-label="Exceptions">
+          @for (item of exceptions(); track item.exceptionId) {
+            <li class="ds-list__item">
+              <div class="ds-list__row">
+                <div class="foreman-exceptions-worker">{{ item.workerName }}</div>
+                <app-status-badge [tone]="'warning'" [label]="item.status"></app-status-badge>
+              </div>
+              <div class="foreman-exceptions-meta">
+                <div class="foreman-exceptions-meta__item">
+                  <span class="foreman-exceptions-meta__label">Type</span>
+                  <span>{{ item.type }}</span>
+                </div>
+                <div class="foreman-exceptions-meta__item">
+                  <span class="foreman-exceptions-meta__label">Details</span>
+                  <span>
+                    @if (item.type === 'MISSING_CHECK_OUT') {
+                      Missing check-out
+                    } @else {
+                      {{ item.reviewReason || 'Review request' }}
+                    }
+                  </span>
+                </div>
+              </div>
+            </li>
+          }
+        </ul>
+      </div>
+      <div class="foreman-exceptions-table">
+        <div class="ds-table-wrap">
+          <table class="ds-table" aria-label="Exceptions">
+            <thead>
               <tr>
-                <td>{{ item.workerName }}</td>
-                <td>{{ item.type }}</td>
-                <td>
-                  @if (item.type === 'MISSING_CHECK_OUT') {
-                    Missing check-out
-                  } @else {
-                    {{ item.reviewReason || 'Review request' }}
-                  }
-                </td>
-                <td>
-                  <app-status-badge [tone]="'warning'" [label]="item.status"></app-status-badge>
-                </td>
+                <th>Worker</th>
+                <th>Type</th>
+                <th>Details</th>
+                <th>Status</th>
               </tr>
-            }
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              @for (item of exceptions(); track item.exceptionId) {
+                <tr>
+                  <td>{{ item.workerName }}</td>
+                  <td>{{ item.type }}</td>
+                  <td>
+                    @if (item.type === 'MISSING_CHECK_OUT') {
+                      Missing check-out
+                    } @else {
+                      {{ item.reviewReason || 'Review request' }}
+                    }
+                  </td>
+                  <td>
+                    <app-status-badge [tone]="'warning'" [label]="item.status"></app-status-badge>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
       </div>
     }
   }


### PR DESCRIPTION
## Summary
- add mobile list view for Foreman Exceptions
- preserve existing table on >=768px
- keep status badge visible in list layout

## Testing
- npm run lint (frontend) **fails due to pre-existing formatting warnings in admin/foreman shell and admin roster files**
- npm run build (frontend)
- npm run test -- --watch=false (frontend)

## Manual QA
- Not run (UI check needed in browser)

Closes #51